### PR TITLE
Add FocusBar opacity slider with persistence

### DIFF
--- a/TodoApp/Views/FocusBar/FocusBarView.swift
+++ b/TodoApp/Views/FocusBar/FocusBarView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Focus bar UI containing an opacity slider.
+struct FocusBarView: View {
+    /// Binding to the current bar opacity stored in `UserDefaults`.
+    @Binding var opacity: Double
+
+    var body: some View {
+        Slider(value: $opacity, in: 0.2...1)
+            .padding(.horizontal)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.ultraThinMaterial)
+    }
+}
+
+#if DEBUG
+#Preview {
+    FocusBarView(opacity: .constant(0.8))
+        .frame(width: 800, height: 28)
+}
+#endif


### PR DESCRIPTION
## Summary
- add `FocusBarView` with an opacity slider
- integrate `FocusBarView` into `FocusBarWindowController`
- persist the opacity using `@AppStorage`
- update window alpha when slider changes

## Testing
- `xcodebuild test -scheme Todo -destination 'platform=macOS'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411d90fad483219a6dac62e2894fd4